### PR TITLE
Remove redundant methods for handling invalid recipe name

### DIFF
--- a/src/main/java/recipeio/CommandValidator.java
+++ b/src/main/java/recipeio/CommandValidator.java
@@ -226,16 +226,6 @@ public class CommandValidator {
         return true;
     }
 
-    /**
-     * Check if the entries of the add command contains the write delimiter.
-     * @param userInput The user's input from the CLI.
-     * @return false if the entries in the add command contain the write delimiter and true otherwise.
-     */
-    public static boolean isValidAddEntries(String userInput) {
-        String entries = userInput.substring(ADD_COMMAND_ENRIES_START_INDEX);
-        return !entries.contains(StorageConstants.WRITE_DELIMITER);
-    }
-
     public static boolean isValidAddCommand(String userInput) {
         String[] details = InputParser.splitUpAddInput(userInput);
         if (details.length != InputParserConstants.TOTAL_INGREDIENTS_INDEX) {
@@ -245,10 +235,6 @@ public class CommandValidator {
             return false;
         }
 
-        if (!isValidAddEntries(userInput)) {
-            System.out.println("Please remove the '|' character from the data entries.");
-            return false;
-        }
         String[] remainingInput = splitUpAddInput(userInput);
         if (!isName(remainingInput[RECIPE_NAME_INDEX])) {
             return false;

--- a/src/test/java/vaildator/CommandValidatorTest.java
+++ b/src/test/java/vaildator/CommandValidatorTest.java
@@ -151,15 +151,4 @@ public class CommandValidatorTest {
         assertFalse(CommandValidator.isValidAddCommand(test));
     }
 
-    @Test
-    public void isValidAddEntries_validEntries_expectedTrue() {
-        String test = "add pizza, abc, 340, egg nut dairy gluten, dinner, www.food.com";
-        assertTrue(CommandValidator.isValidAddEntries(test));
-    }
-
-    @Test
-    public void isValidAddEntries_invalidEntries_expectedFalse() {
-        String test = "add pizza, ab | c, 340, egg nut dairy gluten, dinner, www.food.com";
-        assertFalse(CommandValidator.isValidAddEntries(test));
-    }
 }


### PR DESCRIPTION
Since the ```|``` is handled in the ```isName``` method, I removed the redundant code in ```isValidAddCommand()``` method to make the code base cleaner 